### PR TITLE
fix(gameobjects): remove sound on arrow keypress

### DIFF
--- a/src/gameobjects/keys.ts
+++ b/src/gameobjects/keys.ts
@@ -1,6 +1,6 @@
 import type { Key as KaboomKey } from 'kaboom';
 
-import { DirectionKey, Key, Sound, Tag } from '../constants';
+import { DirectionKey, Key, Tag } from '../constants';
 import { getArea, getPosition, isDirectionKeyPressed } from '../helpers';
 import { incrementScore } from './score';
 import { addStar } from './star';
@@ -36,9 +36,7 @@ export function addKeys() {
       return;
     }
     keyObject.opacity = 1;
-    play(Sound.score, {
-      volume: 0.5,
-    });
+    // Disabled sound on keypress below
   }
 
   function handleRelease(key: KaboomKey) {


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

- Fix

## What is the current behavior?

- On every keypress for the arrows, a sound is played that may distract some players from the music.

## What is the new behavior?

- The sound on keypress has been removed.

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [X] [Conventional Commits](https://www.conventionalcommits.org/)
- [X] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->
